### PR TITLE
fix(core): make callbacks config optional

### DIFF
--- a/packages/core/src/config-helpers.test.ts
+++ b/packages/core/src/config-helpers.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { withDefaults } from "./config-helpers";
+
+describe("withDefaults", () => {
+  it("defaults callbacks to an empty object when omitted", () => {
+    const result = withDefaults({});
+    expect(result.callbacks).toEqual({});
+  });
+
+  it("preserves user-provided callbacks", () => {
+    const getUser = async () => undefined;
+    const result = withDefaults({ callbacks: { getUser } });
+    expect(result.callbacks.getUser).toBe(getUser);
+  });
+});

--- a/packages/core/src/config-helpers.ts
+++ b/packages/core/src/config-helpers.ts
@@ -5,6 +5,7 @@ export type NextlyticsConfigWithDefaults = Required<
 > &
   NextlyticsConfig & {
     anonymousUsers: Required<NonNullable<NextlyticsConfig["anonymousUsers"]>>;
+    callbacks: NonNullable<NextlyticsConfig["callbacks"]>;
   };
 
 export function withDefaults(config: NextlyticsConfig): NextlyticsConfigWithDefaults {
@@ -14,6 +15,7 @@ export function withDefaults(config: NextlyticsConfig): NextlyticsConfigWithDefa
     eventEndpoint: config.eventEndpoint ?? "/api/event",
     isApiPath: config.isApiPath ?? ((str: string) => str.startsWith("/api")),
     backends: config.backends ?? [],
+    callbacks: config.callbacks ?? {},
     anonymousUsers: {
       gdprMode: config.anonymousUsers?.gdprMode ?? true,
       useCookies: config.anonymousUsers?.useCookies ?? false,

--- a/packages/core/src/server.tsx
+++ b/packages/core/src/server.tsx
@@ -245,7 +245,9 @@ export function Nextlytics(userConfig: NextlyticsConfig): NextlyticsResult {
     if (!ctx) {
       // x-nl-page-render-id absent → check if middleware is at least active
       if (!headersList.get(headerNames.active)) {
-        console.warn("[Nextlytics] nextlyticsMiddleware should be added in order for Server to work");
+        console.warn(
+          "[Nextlytics] nextlyticsMiddleware should be added in order for Server to work"
+        );
       }
       return <>{children}</>;
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -164,7 +164,7 @@ export type NextlyticsConfig = {
   isApiPath?: (path: string) => boolean;
   /** Endpoint for client events. Default: "/api/event" */
   eventEndpoint?: string;
-  callbacks: {
+  callbacks?: {
     /** Resolve authenticated user from request context */
     getUser?: (ctx: RequestContext) => Promise<UserContext | undefined>;
     /** Override anonymous user ID generation */


### PR DESCRIPTION
## Summary

- `Nextlytics({ backends: [...] })` without `callbacks` crashed with
  `TypeError: Cannot read properties of undefined (reading 'getUser')`
- The README and quickstart present `callbacks` as optional, but the type required it and `withDefaults` did not provide a default. `server.tsx` and `api-handler.ts` dereferenced `undefined`.
- Mark `callbacks` optional on `NextlyticsConfig`, default it to `{}` in `withDefaults`, and add a small regression test.

Found while running an external e2e (Next 15 + Next 16 apps using `postgrestBackend`) — events stopped landing in the destination until I added `callbacks: {}` to the config.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (new `config-helpers.test.ts` locks the behavior)
- [x] Manually re-ran the minimal quickstart config (no `callbacks` field) — middleware now dispatches and events arrive at PostgREST