### PR TITLE
fix: await delivery in analytics().sendEvent()

### DIFF
--- a/packages/core/src/server.tsx
+++ b/packages/core/src/server.tsx
@@ -335,7 +335,13 @@ export function Nextlytics(userConfig: NextlyticsConfig): NextlyticsResult {
           userContext,
           properties: { ...propsFromCallback, ...opts?.props },
         };
-        await dispatchEventInternal(event, ctx);
+        // Await full delivery, not just dispatch kickoff. Unlike the middleware
+        // page-view path (which defers `completion` with `after()`), an explicit
+        // sendEvent has no response to ride on — in a serverless function the
+        // process can freeze right after this returns, dropping in-flight backend
+        // writes. Awaiting `completion` makes `await sendEvent()` mean "delivered".
+        const { completion } = dispatchEventInternal(event, ctx);
+        await completion;
 
         return { ok: true };
       },


### PR DESCRIPTION
## What

`analytics().sendEvent()` awaited the *dispatch kickoff* but not the `completion` promise:

```ts
await dispatchEventInternal(event, ctx); // returns { clientActions, completion } synchronously
return { ok: true };
```

`dispatchEventInternal` returns immediately, so backend writes (Neon insert, Jitsu POST, …) were effectively fire-and-forget.

## Why it matters

The middleware page-view path defers `completion` with `after()` so it survives past the response. An explicit `sendEvent` from an API route / server action has no such hook — in a **serverless** function the process can freeze right after the response returns, dropping the in-flight writes. So `await sendEvent()` did **not** guarantee delivery (it works locally only because the dev server stays alive).

## Fix

Await `completion`:

```ts
const { completion } = dispatchEventInternal(event, ctx);
await completion;
return { ok: true };
```

Now `await sendEvent()` means "delivered". The middleware page-view path is unchanged (it never calls `sendEvent`).

## Testing

typecheck + all tests pass.